### PR TITLE
Revamp writing animation layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,8 @@
 body {
   font-family: 'Hiragino Sans', 'Noto Sans JP', 'Yu Gothic', 'Meiryo', sans-serif;
   line-height: 1.6;
-  color: #333;
-  background-color: #f8f9fa;
+  color: #1f1f1f;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.9), #f5f5f7 55%, #ebedf3);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -79,9 +79,9 @@ body {
 
 /* Layout */
 .container {
-  max-width: 480px;
+  max-width: 620px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 24px;
   width: 100%;
 }
 
@@ -138,12 +138,14 @@ body {
 }
 
 .card {
-  background: white;
-  border-radius: 16px;
-  padding: 24px;
-  margin: 16px 0;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  text-align: center;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  padding: 32px;
+  margin: 24px 0;
+  box-shadow: 0 24px 40px -28px rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(18px);
+  text-align: left;
 }
 
 .practice-card {
@@ -461,80 +463,198 @@ body {
   }
 }
 
+.writing-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-bottom: 48px;
+}
+
+.writing-hero {
+  padding: 40px;
+}
+
+.writing-hero-header {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  justify-content: space-between;
+  margin-bottom: 32px;
+}
+
+@media (min-width: 720px) {
+  .writing-hero-header {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.writing-subtitle {
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #6b7280;
+  font-weight: 600;
+}
+
+.writing-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.writing-switchers {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.segmented-control {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 4px;
+}
+
+.segmented-control.soft {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.segment {
+  border: none;
+  background: transparent;
+  color: #475569;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 10px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.segment:hover {
+  color: #0f172a;
+}
+
+.segment.active {
+  background: white;
+  color: #0f172a;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+}
+
 .selected-animation {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 24px;
 }
 
 .selected-animation-preview {
   width: 100%;
+  max-width: 440px;
+  padding: 24px;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(207, 217, 255, 0.65));
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 24px 40px -30px rgba(15, 23, 42, 0.55);
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 16px;
-  border-radius: 20px;
-  background: radial-gradient(circle at top, #ffffff 0%, #e6f0ff 60%, #d0e1ff 100%);
-  box-shadow: 0 10px 25px rgba(0, 123, 255, 0.2);
 }
 
 .selected-animation-preview img {
   width: 100%;
-  max-width: 360px;
-  border-radius: 16px;
-  border: 4px solid rgba(255, 255, 255, 0.85);
-  background: #f8f9fa;
+  max-width: 320px;
+  border-radius: 20px;
+  box-shadow: 0 18px 38px -28px rgba(15, 23, 42, 0.55);
+  background: #ffffff;
 }
 
 .selected-animation-caption {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
 }
 
 .selected-kana {
-  font-size: 3rem;
+  font-size: 3.2rem;
   font-weight: 700;
-  color: #1c3f94;
+  color: #111827;
 }
 
 .selected-romaji {
-  font-size: 1.4rem;
-  color: #1c7ed6;
+  font-size: 1.2rem;
+  color: #6b7280;
   font-weight: 600;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.animation-grid {
+.animation-collection {
+  padding: 36px 40px;
+}
+
+.animation-collection-header h3 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.animation-collection-header p {
+  margin-top: 8px;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.empty-state {
+  text-align: center;
+  color: #6b7280;
+  padding: 32px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+}
+
+.animation-matrix {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.animation-row {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 12px;
 }
 
 .animation-item {
-  background: white;
-  border: 2px solid transparent;
-  border-radius: 16px;
-  padding: 12px 10px;
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 22px;
+  padding: 16px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(244, 247, 255, 0.85));
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   cursor: pointer;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  aspect-ratio: 1 / 1;
 }
 
 .animation-item:hover {
   transform: translateY(-4px);
-  box-shadow: 0 10px 18px rgba(0, 123, 255, 0.18);
+  box-shadow: 0 18px 32px -28px rgba(15, 23, 42, 0.45);
 }
 
 .animation-item.selected {
-  border-color: #1c7ed6;
-  box-shadow: 0 12px 22px rgba(28, 126, 214, 0.25);
+  border-color: rgba(99, 102, 241, 0.45);
+  box-shadow: 0 20px 34px -26px rgba(99, 102, 241, 0.45);
 }
 
 .animation-thumb {
@@ -542,14 +662,14 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 6px;
-  border-radius: 12px;
-  background: linear-gradient(135deg, rgba(28, 126, 214, 0.15), rgba(28, 126, 214, 0.05));
+  padding: 12px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.16), rgba(99, 102, 241, 0.05));
 }
 
 .animation-thumb img {
-  width: 80px;
-  height: 80px;
+  width: 72px;
+  height: 72px;
   object-fit: contain;
 }
 
@@ -557,33 +677,46 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
 }
 
 .animation-kana {
   font-size: 1.6rem;
-  color: #2c3e50;
+  color: #0f172a;
   font-weight: 600;
 }
 
 .animation-romaji {
-  font-size: 0.95rem;
-  color: #1c7ed6;
+  font-size: 0.85rem;
+  color: #64748b;
   font-weight: 600;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.animation-placeholder {
+  border-radius: 22px;
+  border: 1px solid transparent;
+  background: transparent;
+  aspect-ratio: 1 / 1;
 }
 
 @media (min-width: 768px) {
+  .writing-switchers {
+    flex-direction: row;
+  }
+
   .selected-animation-preview {
-    padding: 24px;
+    padding: 32px;
+    max-width: 520px;
   }
 
   .selected-animation-preview img {
-    max-width: 420px;
+    max-width: 360px;
   }
 
   .animation-thumb img {
-    width: 92px;
-    height: 92px;
+    width: 84px;
+    height: 84px;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the writing animation page to focus on the gif experience with a simplified two-card layout
- organize the animation gallery into a consistent five-column gojūon-inspired grid with segmented controls
- refresh the page styling with softer colors, expanded spacing, and new Apple-inspired typography treatments

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911333e3064832d9e6484bd0ecd1348)